### PR TITLE
Added scripts to install and uninstall dcafs.service (systemd).

### DIFF
--- a/install_as_service.sh
+++ b/install_as_service.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+SERVICE_NAME='dcafs.service'
+SCRIPT="$(readlink --canonicalize-existing "$0")"
+SCRIPT_PATH="$(dirname "$SCRIPT")"
+JAR_FILE=$(echo ` ls | grep dcafs*.jar`)
+
+SERVICE_PATH="/lib/systemd/system"
+SERVICE_FILE=$SERVICE_PATH/$SERVICE_NAME
+
+sudo cat > $SERVICE_FILE << EOF
+[Unit]
+Description=Dcafs Data Acquisition System Service
+After=multi-user.target
+[Service]
+Type=simple
+ExecStart=java -jar $SCRIPT_PATH/$JAR_FILE
+Restart=on-failure
+RestartSec=3s
+[Install]
+WantedBy=multi-user.target
+EOF
+
+chmod 644 $SERVICE_FILE
+
+systemctl daemon-reload
+systemctl enable $SERVICE_NAME
+systemctl start $SERVICE_NAME
+systemctl status $SERVICE_NAME

--- a/uninstall_dcafs_service.sh
+++ b/uninstall_dcafs_service.sh
@@ -1,0 +1,6 @@
+sudo systemctl stop dcafs.service
+sudo systemctl disable dcafs.service
+sudo  rm -f /lib/systemd/system/dcafs.service
+sudo systemctl daemon-reload
+sudo systemctl reset-failed
+


### PR DESCRIPTION
This allows to to start dcafs at boot and to restart it in case of failure. It will reboot after 3s.
Also allows the use of systemctl commands : status,restart,enable,...
Allows a log as well with journalctl.